### PR TITLE
make _LazyString hashable

### DIFF
--- a/speaklater.py
+++ b/speaklater.py
@@ -162,6 +162,9 @@ class _LazyString(object):
     def __eq__(self, other):
         return self.value == other
 
+    def __hash__(self):
+        return hash(self.value)
+
     def __ne__(self, other):
         return self.value != other
 


### PR DESCRIPTION
I am trying to fix a I18n problem in quokka project, And may need _LazyString to be a hashable object.
The reason is that flask-admin will use a dict to organize it's menu category, so using a non-hashable object as menu category will cause problem. So here is the PR
