### PR TITLE
Add 'format' method to LazyString

### DIFF
--- a/speaklater.py
+++ b/speaklater.py
@@ -194,6 +194,13 @@ class _LazyString(object):
         except Exception:
             return '<%s broken>' % self.__class__.__name__
 
+    def format(self, **params):
+        try:
+            translated = unicode(self)
+        except NameError:
+            translated = str(self)
+        return translated.format(**params)
+
 
 if __name__ == '__main__':
     import doctest


### PR DESCRIPTION
The patch provides a way to include a basic use of format() on LazyString instances like it works for string:

> > > import speaklater
> > > translations = {"Yes {name}": "Ja {name}"}
> > > lazy_gettext = speaklater.make_lazy_gettext(lambda: translations.get)
> > > ls = lazy_gettext("Yes {name}")
> > > ls.format(name="Alice")
> > > 'Ja Alice'

The goal of the try/except block is to be compatible under python2 and 3. I tested the code under both interpreters (2.7.3 and 3.4.3rc1).

The optional  'format_spec' parameter of format() is not included but I can add it if you are interested.
