### PR TITLE
Enable building on python3 along with changes to doctest to work unde…

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ setup(
     author_email='armin.ronacher@active-4.com',
     version='1.3',
     url='http://github.com/mitsuhiko/speaklater',
+    use_2to3=True,
     py_modules=['speaklater'],
     description='implements a lazy string for python useful for use with gettext',
     long_description=get_docs(),

--- a/speaklater.py
+++ b/speaklater.py
@@ -13,23 +13,23 @@ r"""
     Example:
 
     >>> from speaklater import make_lazy_string
-    >>> sval = u'Hello World'
+    >>> sval = 'Hello World'
     >>> string = make_lazy_string(lambda: sval)
 
     This lazy string will evaluate to the value of the `sval` variable.
 
     >>> string
-    lu'Hello World'
-    >>> unicode(string)
-    u'Hello World'
+    l'Hello World'
+    >>> str(string)
+    'Hello World'
     >>> string.upper()
-    u'HELLO WORLD'
+    'HELLO WORLD'
 
     If you change the value, the lazy string will change as well:
 
-    >>> sval = u'Hallo Welt'
+    >>> sval = 'Hallo Welt'
     >>> string.upper()
-    u'HALLO WELT'
+    'HALLO WELT'
 
     This is especially handy when combined with a thread local and gettext
     translations or dicts of translatable strings:
@@ -42,7 +42,7 @@ r"""
     >>> yes = lazy_gettext(u'Yes')
     >>> print yes
     Ja
-    >>> l.translations[u'Yes'] = u'Si'
+    >>> l.translations[u'Yes'] = 'Si'
     >>> print yes
     Si
 
@@ -83,14 +83,14 @@ def make_lazy_gettext(lookup_func):
 
     Example:
 
-    >>> translations = {u'Yes': u'Ja'}
+    >>> translations = {'Yes': 'Ja'}
     >>> lazy_gettext = make_lazy_gettext(lambda: translations.get)
-    >>> x = lazy_gettext(u'Yes')
+    >>> x = lazy_gettext('Yes')
     >>> x
-    lu'Ja'
-    >>> translations[u'Yes'] = u'Si'
+    l'Ja'
+    >>> translations['Yes'] = 'Si'
     >>> x
-    lu'Si'
+    l'Si'
     """
     def lazy_gettext(string):
         if is_lazy_string(string):


### PR DESCRIPTION
…r both python2 and python3

This enables building a python3 version of the module via 2to3.  It also modifies the doctests so that they work under both python2 and python3 (by using the concept of native strings that the wsgi folks popularized).

I'll understand if you don't like this -- it isn't my favorite approach to either of these problems either.  But it would be appreciated if you could look at this and @ThomasWaldmann's approach in https://github.com/mitsuhiko/speaklater/pull/3 and decide if either of them are worth working on more.  I'd be willing to do more work to make either approach better but don't know what your criteria for a preferred solution would be.

Fixes #2 
